### PR TITLE
adds 'interrupted' status, updates pw ver

### DIFF
--- a/build/src/index.js
+++ b/build/src/index.js
@@ -8,6 +8,7 @@ var JSONSummaryReporter = /** @class */ (function () {
         this.skipped = [];
         this.failed = [];
         this.warned = [];
+        this.interrupted = [];
         this.timedOut = [];
         this.status = 'unknown';
         this.startedAt = 0;
@@ -31,7 +32,7 @@ var JSONSummaryReporter = /** @class */ (function () {
         }
         // This will publish the file name + line number test begins on
         var z = "".concat(fileName[0], ":").concat(test.location.line, ":").concat(test.location.column);
-        // Using the t variable in the push will push a full test test name + test description
+        // Using the t variable in the push will push a full test name + test description
         var t = title.join(' > ');
         var status = !['passed', 'skipped'].includes(result.status) && t.includes('@warn')
             ? 'warned'
@@ -48,8 +49,13 @@ var JSONSummaryReporter = /** @class */ (function () {
         });
         // removing duplicate and flakey (passed on a retry) tests from the failed array
         this.failed = this.failed.filter(function (element, index) {
-            if (!_this.passed.includes(element))
-                return _this.failed.indexOf(element) === index;
+            var isRealFailure = false;
+            var isNotFlaky = !_this.passed.includes(element);
+            if (isNotFlaky) {
+                var isNotDuplicate = _this.failed.indexOf(element) === index;
+                isRealFailure = isNotDuplicate;
+            }
+            return isRealFailure;
         });
         fs.writeFileSync('./summary.json', JSON.stringify(this, null, '  '));
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "@butchmayhew/playwright-json-summary-reporter",
-  "version": "1.1.1",
+  "name": "playwright-json-summary-reporter",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@butchmayhew/playwright-json-summary-reporter",
-      "version": "1.1.1",
+      "name": "playwright-json-summary-reporter",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@playwright/test": "^1.29.2",
-        "@types/node": "^14.11.2",
+        "@playwright/test": "^1.32.3",
+        "@types/node": "^14.18.42",
         "gts": "^3.1.1",
-        "typescript": "~4.7.0"
+        "typescript": "~4.7.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -203,19 +203,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
-      "integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.29.2"
+        "playwright-core": "1.32.3"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@types/json-schema": {
@@ -231,9 +234,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "version": "14.18.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
+      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1323,6 +1326,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2148,9 +2165,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
-      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -3043,13 +3060,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
-      "integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.29.2"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.3"
       }
     },
     "@types/json-schema": {
@@ -3065,9 +3083,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "version": "14.18.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
+      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3837,6 +3855,13 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4451,9 +4476,9 @@
       "dev": true
     },
     "playwright-core": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
-      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+      "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
       "dev": true
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-json-summary-reporter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Simple Playwright Reporter",
   "license": "MIT",
   "repository": "playwrightsolutions/playwright-json-summary-reporter",
@@ -13,10 +13,10 @@
     "playwright-reporter"
   ],
   "devDependencies": {
-    "@playwright/test": "^1.29.2",
-    "@types/node": "^14.11.2",
+    "@playwright/test": "^1.32.3",
+    "@types/node": "^14.18.42",
     "gts": "^3.1.1",
-    "typescript": "~4.7.0"
+    "typescript": "~4.7.4"
   },
   "scripts": {
     "lint": "gts lint",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import type {PlaywrightTestConfig} from '@playwright/test';
+import {devices} from '@playwright/test';
 
 /**
  * Read environment variables from file.
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 5000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
adds field for 'interrupted' status, fixes duplicate word, adds explanatory variables and full codepath coverage to `test.failed` flake/dupe logic, updates playwright to latest version and node/ts to new minimum